### PR TITLE
Add install instructions without package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ You can read compile errors/warnings by about 1sec.
 
 # :dizzy: How to install :dizzy:
 
+No package manager
+
+clone this repo into `$MYVIMRC/pack/haskell/start/`
+
 dein.nvim
 
 ```haskell


### PR DESCRIPTION
In vim 8.0+ it's possible to have packages without using an external
package manager, and since this require vim 8.0+, it makes sense to
include these instructions.