### PR TITLE
Keep cursor still when Quickfix window pops open

### DIFF
--- a/autoload/ghcid_quickfix/event_hooks/show_only_error_occured.vim
+++ b/autoload/ghcid_quickfix/event_hooks/show_only_error_occured.vim
@@ -17,6 +17,7 @@ function! ghcid_quickfix#event_hooks#show_only_error_occured#new(qf_bufnr) abort
       echomsg 'All good'
     elseif ghcid_quickfix#lines#match_error(a:line)
       copen
+      wincmd p
     endif
   endfunction
 


### PR DESCRIPTION
I've been using this plugin a lot these days. One big problem is that upon errors the quickfix window opens up (which is good) but then the cursor jumps into it (which is annoying).

I tried this change and is so much better!  though it's probably better to make this a configurable behavior (?)