### PR TITLE
Let user know when there are warnings

### DIFF
--- a/autoload/ghcid_quickfix/event_hooks/show_only_error_occured.vim
+++ b/autoload/ghcid_quickfix/event_hooks/show_only_error_occured.vim
@@ -15,6 +15,9 @@ function! ghcid_quickfix#event_hooks#show_only_error_occured#new(qf_bufnr) abort
     elseif ghcid_quickfix#lines#match_all_good(a:line)
       cclose
       echomsg 'All good'
+    elseif ghcid_quickfix#lines#match_warning(a:line)
+      cclose
+      echomsg 'Compiled with warnings'
     elseif ghcid_quickfix#lines#match_error(a:line)
       copen
     endif


### PR DESCRIPTION
In the same vein fo #14, It is annoying when It compiles successfully but, because there are warnings, it remains silent and lefts the user wondering if it's done compiling or not.

So let the user know with a `Compiled with warnings` message :)