### PR TITLE
fix typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ You can read compile errors/warnings by about 1sec.
 
 clone this repo into `$MYVIMRC/pack/haskell/start/`
 
-### dein.nvim
+### dein.vim
 
 ```haskell
 call dein#add('aiya000/vim-ghcid-quickfix')
 ```
 
-### dein.nvim with toml
+### dein.vim with toml
 
 ```toml
 [[plugins]]


### PR DESCRIPTION
Although it was trivial, I found a typo and modified it. Verification please.

I think `dein.vim` is correct.

## Reference

> https://github.com/Shougo/dein.vim